### PR TITLE
Update setup-logrotate.ps1

### DIFF
--- a/src/windows/setup-logrotate.ps1
+++ b/src/windows/setup-logrotate.ps1
@@ -26,7 +26,7 @@ if ($? -eq $True) {
 
   Set-Location $logrotate_directory
 
-  pm2 install . --silent
+  pm2 install . -no-daemon
 
   # Go back to where we were
   Set-Location $wd


### PR DESCRIPTION
Added -no-daemon to "pm2 install . -no-daemon" in setup-logrotate.ps1 script so that logrotate will run in no daemon mode. log rotate install seems to stuck with this log entry "[PM2] Spawning PM2 daemon with pm2_home=C:\ProgramData\pm2\home" and updating the install command as `pm2 install . -no-daemon` might help to over come the issue

# Description

<!--  What has changed in this PR? -->

## Testing

<!--  Which environments has this change been tested in? -->

## Fixes or features?

<!-- Does this fix bugs or add new features? Link any appropriate issues -->
